### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Bluebook Signals for Zotero
 
 Bluebook Signals for Zotero adds a pulldown menu of standard Bluebook signals in the prefix field of the word processor integration plugin widgets used by Zotero or MLZ.
 
-To download the add-on and for instructions see the project [webpage](http://fbennett.github.io/bluebook-signals-for-zotero/)
+To download the add-on and for instructions see the project [webpage](http://juris-m.github.io/bluebook-signals-for-zotero/)
 
 It's a pretty simple thing, but patches, pull requests and suggestions for improvement are welcome.


### PR DESCRIPTION
Compare the webpage link on https://github.com/Juris-M/bluebook-signals-for-zotero#readme to the one on https://github.com/benzax/bluebook-signals-for-zotero#readme
